### PR TITLE
Bug fixes!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## pcrappyfuzzer
 
-pcrappyfuzzer.py: a very simple mash-up of Scapy + radamsa to extract data from a PCAP file and perform quick 'n dirty fuzzing ad infinitum.
+pcrappyfuzzer.py: a very simple mash-up of Scapy + [radamsa](https://github.com/aoh/radamsa) to extract data from a PCAP file and perform quick 'n dirty fuzzing ad infinitum.
 
 Originally written for a penetration testing engagement, but modified
 to support the blog post "Fuzzing proprietary protocols with Scapy,

--- a/pcrappyfuzzer.py
+++ b/pcrappyfuzzer.py
@@ -27,6 +27,7 @@ try:
     import scapy.all as scapy
 except ImportError:
     print "[!] 'scapy' module not found."
+    exit(1)
 
 
 VERBOSE = False

--- a/pcrappyfuzzer.py
+++ b/pcrappyfuzzer.py
@@ -11,7 +11,7 @@
 # Copyright 2016-2017, Blaze Information Security
 # https://www.blazeinfosec.com
 
-import scapy.all as scapy
+
 from subprocess import Popen, PIPE
 import ssl
 import socket
@@ -20,6 +20,14 @@ import time
 import argparse
 import os
 import sys
+import logging
+import time
+logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
+try:
+    import scapy.all as scapy
+except ImportError:
+    print "[!] 'scapy' module not found."
+
 
 VERBOSE = False
 PCAP_LOCATION = './test.pcap'
@@ -76,6 +84,7 @@ def main():
     arg.add_argument("-p", action="store", dest="port", help="Destination Port - Port Default: 443")
     arg.add_argument("-f", action="store", dest="file", help="Input File Location")
     arg.add_argument("-z", action="store", dest="fuzz", help="Fuzz Factor - Default: 50.0")
+    arg.add_argument("-s", action="store_true", dest="ssl", default=False, help="Enables SSL")
     arg.add_argument("-v", action="version", version="%(prog)s 1.0")
     
     result = arg.parse_args()
@@ -83,9 +92,17 @@ def main():
     if result.host:
         HOST=result.host
     if result.port:
-        PORT=result.port
+        try:
+            PORT=int(result.port)
+        except ValueError:
+            print "[!] Option 'port' should be integer"
+            exit(1)
     if result.fuzz:
-        FUZZ_FACTOR=result.fuzz
+        try:
+            FUZZ_FACTOR=int(result.fuzz)
+        except ValueError:
+            print "[!] Option 'fuzz' should be integer"
+            exit(1)
     if result.file:
         PCAP_LOCATION=result.file
     if not os.path.exists(PCAP_LOCATION):
@@ -142,8 +159,9 @@ def main():
             fuzz_iterations += 1
             sockfd = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sockfd.settimeout(5)
-            ssl_sockfd = ssl.wrap_socket(sockfd)
-            ssl_sockfd.connect((HOST, PORT))
+            if result.ssl:
+                sockfd = ssl.wrap_socket(sockfd)
+            sockfd.connect((HOST, PORT))
 
             for packet in packets_list:
                 payload = packet[1]
@@ -153,8 +171,8 @@ def main():
                 iterations_str += "\n" + "--- Payload ---\n" + payload + "\n"
                 print payload
 
-                ssl_sockfd.send(payload)
-                received_buffer = ssl_sockfd.recv(2048)
+                sockfd.send(payload)
+                received_buffer = sockfd.recv(2048)
 
                 iterations_str += "\n" + "--- Received ---\n" + received_buffer + "\n"
                 print received_buffer
@@ -168,6 +186,7 @@ def main():
             print error_str
             log_str = error_str + '\n' + iterations_str
             log_events(log_str, "error")
+            time.sleep(10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Filtered `scapy` warnings like below
   `WARNING: No route found for IPv6 destination :: (no default route?)`

2. Converting `port` and `fuzz` options into `Int`. Getting errors like below
```
 [+] Fuzzing iteration number #3808
 [!] Error during iteration #3809: an integer is required
```
```
python pcrappyfuzzer.py -H google.com -p s -f test.pcap
[!] Option 'port' should be integer
```
3.  Added `SSL` option in CLI which is useful when we test application don't have SSL capability or runs on normal `http`(Port 80). Getting below error with port 80
```
   [+] Fuzzing iteration number #0
   [!] Error during iteration 1: [Errno 1] _ssl.c:510: error:140770FC:SSL  routines:SSL23_GET_SERVER_HELLO:unknown protocol
```
4. If connection fails/not able to connect, scripts sleeps for 10 seconds and try

5. Added `radamsa` link in README
```
veeru@ultron:~/Projects/pcrappyfuzzer$ python pcrappyfuzzer.py -h
usage: pcrappyfuzzer.py [-h] [-H HOST] [-p PORT] [-f FILE] [-z FUZZ] [-s] [-v]

A very simple mash-up of Scapy + radamsa to extract data from pcap and perform
fuzzing ad infinitum.

optional arguments:
  -h, --help  show this help message and exit
  -H HOST     Destination IP - Default: 127.0.0.1
  -p PORT     Destination Port - Port Default: 443
  -f FILE     Input File Location
  -z FUZZ     Fuzz Factor - Default: 50.0
  -s          Enables SSL
  -v          show program's version number and exit
```
